### PR TITLE
Issue 17: make CSS file work in production build

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,15 @@ celery -A gm_pr worker -l info --concurrency=20
 
 Open the web page at http://192.168.1.4:8000
 
+Running in production mode:
+---------------------------
+To run in production mode, modify gm_pr/settings_production.py:
+* add at least one host to ALLOWED_HOSTS (https://docs.djangoproject.com/en/stable/ref/settings#allowed-hosts)
+* set STATIC_URL to a full url.  An external webserver must serve files at this url.
+  Example: http://example.com/static/
+* copy the contents of the gm_pr/static folder to the folder served at STATIC_URL.
+* Run the "runserver" and "celeryd" commands, with the production config:
+```
+python3 manage.py runserver 192.168.1.4:8000 --settings gm_pr.settings_production &
+python3 manage.py celeryd --setting=gm_pr.settings_production
+```

--- a/gm_pr/settings.py
+++ b/gm_pr/settings.py
@@ -1,6 +1,7 @@
 # Django settings for gm_pr project.
 
 import os
+from gm_pr.settings_projects import *
 
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
@@ -166,24 +167,3 @@ LOGGING = {
     }
 }
 
-GITHUB_LOGIN = "foo@genymobile.com"
-GITHUB_PASSWORD = "password"
-#web version
-WEB_URL = "http://jenkins.genymobile.com/gm_pr/"
-SLACK_TOKEN = "s9Wdn8diWL8bGItBNL1SuEIz"
-SLACK_URL = "https://hooks.slack.com/services/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"
-
-TOP_LEVEL_URL = "https://api.github.com"
-ORG = "Genymobile"
-# Number of days a PRs without update can be flagged as OLD.
-OLD_PERIOD=4
-# only PRs with one of those labels can be considered as OLD.
-# Use None for "no label"
-OLD_LABELS=("Needs Reviews", None)
-
-PROJECTS_CHAN = \
-    { 'general' : ("genymotion-binocle",
-                  ),
-      'random' : ('FridgeCheckup',
-                 ),
-    }

--- a/gm_pr/settings_production.py
+++ b/gm_pr/settings_production.py
@@ -1,0 +1,14 @@
+# Django settings for gm_pr project, production environment.
+from gm_pr.settings import *
+
+DEBUG = False
+TEMPLATE_DEBUG = False
+
+# Hosts/domain names that are valid for this site; required if DEBUG is False
+# See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
+ALLOWED_HOSTS = [ "127.0.0.1"]
+
+# URL prefix for static files.
+# Example: "http://example.com/static/", "http://static.example.com/"
+STATIC_URL = 'http://example.com/static/'
+

--- a/gm_pr/settings_projects.py
+++ b/gm_pr/settings_projects.py
@@ -1,0 +1,26 @@
+# Django settings for gm_pr projects.
+
+import os
+
+GITHUB_LOGIN = "foo@genymobile.com"
+GITHUB_PASSWORD = "password"
+#web version
+WEB_URL = "http://jenkins.genymobile.com/gm_pr/"
+SLACK_TOKEN = "s9Wdn8diWL8bGItBNL1SuEIz"
+SLACK_URL = "https://hooks.slack.com/services/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"
+
+TOP_LEVEL_URL = "https://api.github.com"
+ORG = "Genymobile"
+# Number of days a PRs without update can be flagged as OLD.
+OLD_PERIOD=4
+# only PRs with one of those labels can be considered as OLD.
+# Use None for "no label"
+OLD_LABELS=("Needs Reviews", None)
+
+PROJECTS_CHAN = \
+    { 'general' : ("genymotion-binocle",
+                  ),
+      'random' : ('FridgeCheckup',
+                 ),
+    }
+

--- a/gm_pr/templates/base.html
+++ b/gm_pr/templates/base.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html public "-//W3C//DTD HTML 4.0//EN">
 <html lang="en">
+{% load staticfiles %}
   <head>
     <title>{% block title %}GM PR{% endblock %}</title>
-    <link rel="stylesheet" type="text/css" href="static/gm_pr.css">
+    <link rel="stylesheet" type="text/css" href="{% static "gm_pr.css" %}">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   </head>
   <body>


### PR DESCRIPTION
* separated the settings.py into three files:
 - settings_projects.py: contains all the parameters that will be customized for different projects (github login, etc)
 - settings_production.py: overrides the needed parameters for a prod environment
 - settings.py: removed the github login and related parameters into settings_projects.py
* Fix to base.html to use the static keyword, so that the right static content will be loaded in debug vs prod builds.
* README.md explained what's needed to run the server in production mode, with static content working

Unfortunately I didn't find a solution to get static content working in a prod environment, without requiring some external web server.